### PR TITLE
Feature: acronyms to models

### DIFF
--- a/database/migrations/2023_04_29_083000_acl_model.php
+++ b/database/migrations/2023_04_29_083000_acl_model.php
@@ -13,13 +13,9 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('acl_group_dependencies', function (Blueprint $table) {
+        Schema::create('acl_models', function (Blueprint $table) {
             $table->id();
-            $table->smallInteger('model_id');
-            $table->foreignId('record_id');
-            $table->foreignId('group_id');
-            $table->tinyInteger('permission_level');
-            $table->index(['model_id', 'record_id']);
+            $table->string('name');
         });
     }
 
@@ -31,6 +27,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('acl_group_dependencies');
+        Schema::dropIfExists('acl_models');
     }
 };

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -7,6 +7,7 @@ namespace Rexpl\LaravelAcl;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Rexpl\LaravelAcl\Exceptions\ResourceNotFoundException;
@@ -40,7 +41,7 @@ class Acl
 
     /**
      * Registered macros.
-     * 
+     *
      * @var array<string,\Closure>
      */
     protected static array $macros = [];
@@ -48,7 +49,7 @@ class Acl
 
     /**
      * Returns the user instance of the specified id.
-     * 
+     *
      * @return \Rexpl\LaravelAcl\User
      */
     public function user(int $id): User
@@ -61,9 +62,9 @@ class Acl
 
     /**
      * Creates a new user.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\User
      */
     public function newUser(int $id): User
@@ -86,10 +87,10 @@ class Acl
 
     /**
      * Delete a user by id.
-     * 
+     *
      * @param int $id
      * @param bool $clean
-     * 
+     *
      * @return void
      */
     public function deleteUser(int $id, bool $clean = true): void
@@ -100,9 +101,9 @@ class Acl
 
     /**
      * Returns whether a user instance is cached or not.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return bool
      */
     protected function isUserInstanceCached(int $id): bool
@@ -113,9 +114,9 @@ class Acl
 
     /**
      * Makes a new user instance with the correct data from the given id.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\User
      */
     protected function makeNewUserInstance(int $id): User
@@ -133,9 +134,9 @@ class Acl
 
     /**
      * Get the user data from the given id.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Internal\UserData
      */
     protected function getUserData(int $id): UserData
@@ -152,9 +153,9 @@ class Acl
 
     /**
      * Fetch from db the needed data for the user.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Internal\UserData
      */
     protected function fetchUserData(int $id): UserData
@@ -172,9 +173,9 @@ class Acl
 
     /**
      * Return all the group id's for a given user.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return array<int>
      */
     protected function fetchAllUserGroups(int $id): array
@@ -198,10 +199,10 @@ class Acl
 
     /**
      * Get all child groups of an array of groups relative to n factor.
-     * 
+     *
      * @param array<int> $groups
      * @param int $nFactor
-     * 
+     *
      * @return array<int>
      */
     protected function fetchAllChildGroups(array $groups, int $nFactor): array
@@ -218,10 +219,10 @@ class Acl
 
     /**
      * Fetch all the permissions a user has access to.
-     * 
+     *
      * @param array<int> $userGroups
      * @param int $nFactor
-     * 
+     *
      * @return array<string>
      */
     protected function fetchAllUserPermissions(array $userGroups, $nFactor): array
@@ -242,10 +243,10 @@ class Acl
 
     /**
      * Get all parent groups of an array of groups relative to n factor.
-     * 
+     *
      * @param array<int> $groups
      * @param int $nFactor
-     * 
+     *
      * @return array<int>
      */
     protected function fetchAllParentGroups(array $groups, int $nFactor): array
@@ -262,11 +263,11 @@ class Acl
 
     /**
      * Execute the cte query.
-     * 
+     *
      * @param array<int> $groups
      * @param int $nFactor
      * @param string $retrieveColumn
-     * 
+     *
      * @return array<int>
      */
     protected function groupFetchQuery(array $groups, int $nFactor, string $retrieveColumn): array
@@ -301,9 +302,9 @@ class Acl
 
     /**
      * Fetches the user std acl.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return array<\Rexpl\LaravelAcl\Internal\StdAclRow>
      */
     protected function fetchUserStdAcl(int $id): array
@@ -321,9 +322,9 @@ class Acl
 
     /**
      * Returns the group instance of the specified id.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Group
      */
     public function group(int $id): Group
@@ -336,9 +337,9 @@ class Acl
 
     /**
      * Creates a new group.
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Group
      */
     public function newGroup(string $name): Group
@@ -353,10 +354,10 @@ class Acl
 
     /**
      * Deletes a group by id.
-     * 
+     *
      * @param int $id
      * @param bool $clean
-     * 
+     *
      * @return void
      */
     public function deleteGroup(int $id, bool $clean = true): void
@@ -367,9 +368,9 @@ class Acl
 
     /**
      * Returns whether a group instance is cached or not.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return bool
      */
     protected function isGroupInstanceCached(int $id): bool
@@ -380,9 +381,9 @@ class Acl
 
     /**
      * Makes a new group instance with the correct data from the given id.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Group
      */
     protected function makeNewGroupInstance(int $id): Group
@@ -395,16 +396,16 @@ class Acl
 
     /**
      * Fetches a group model by id.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Models\Group
      */
     protected function fetchGroupModel(int $id): GroupModel
     {
         $group = GroupModel::find($id);
 
-        if (null === $group) {        
+        if (null === $group) {
             throw new ResourceNotFoundException(sprintf(
                 'Acl group with id: %s, not found.', $id
             ));
@@ -416,37 +417,35 @@ class Acl
 
     /**
      * Returns a record.
-     * 
-     * @param string $acronym
-     * @param int $id
-     * 
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
      * @return \Rexpl\LaravelAcl\Record
      */
-    public function record(string $acronym, int $id): Record
+    public function record(Model $model): Record
     {
-        return new Record($acronym, $id);
+        return new Record($model);
     }
 
 
     /**
      * Deletes record.
-     * 
-     * @param string $acronym
-     * @param int $id
-     * 
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
      * @return void
      */
-    public function deleteRecord(string $acronym, int $id): void
+    public function deleteRecord(Model $model): void
     {
-        $this->record($acronym, $id)->delete();
+        $this->record($model)->delete();
     }
 
 
     /**
      * Create new permission. Return id.
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return int
      */
     public function newPermission(string $name): int
@@ -459,10 +458,10 @@ class Acl
 
     /**
      * Deletes permission.
-     * 
+     *
      * @param int $id
      * @param bool $clean
-     * 
+     *
      * @return void
      */
     public function deletePermission(int $id, bool $clean = true): void
@@ -477,9 +476,9 @@ class Acl
 
     /**
      * Returns the permission name. Returns null if permission not found.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return string|null
      */
     public function permissionName(int $id): ?string
@@ -491,9 +490,9 @@ class Acl
 
     /**
      * Returns the permission id. Returns null if permission not found.
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return int|null
      */
     public function permissionID(string $name): ?int
@@ -505,7 +504,7 @@ class Acl
 
     /**
      * Returns all the permissions.
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function permissions(): Collection
@@ -516,7 +515,7 @@ class Acl
 
     /**
      * Flush the saved instances for long running proccesses.
-     * 
+     *
      * @return void
      */
     public function flush(): void
@@ -528,9 +527,9 @@ class Acl
 
     /**
      * Remove group from saved instances.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return void
      */
     public function clearGroupFromSavedInstances(int $id): void
@@ -543,9 +542,9 @@ class Acl
 
     /**
      * Remove user from saved instances.
-     * 
+     *
      * @param int $id
-     * 
+     *
      * @return void
      */
     public function clearUserFromCache(int $id): void
@@ -560,10 +559,10 @@ class Acl
 
     /**
      * Register a custom macro.
-     * 
+     *
      * @param string $name
      * @param Closure $closure
-     * 
+     *
      * @return void
      */
     public function macro(string $name, Closure $closure): void
@@ -574,9 +573,9 @@ class Acl
 
     /**
      * Check if a macro exists.
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return bool
      */
     public function hasMacro(string $name): bool
@@ -587,7 +586,7 @@ class Acl
 
     /**
      * Clear all macros.
-     * 
+     *
      * @return void
      */
     public function clearMacros(): void
@@ -598,10 +597,10 @@ class Acl
 
     /**
      * Hanlde macro calls.
-     * 
+     *
      * @param string $name
      * @param array $arguments
-     * 
+     *
      * @return mixed
      */
     public function __call($name, $arguments)

--- a/src/Internal/ModelToId.php
+++ b/src/Internal/ModelToId.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rexpl\LaravelAcl\Internal;
+
+use Illuminate\Database\Eloquent\Model;
+use Rexpl\LaravelAcl\Models\AclModel;
+
+trait ModelToId
+{
+    /**
+     * The already fetched model ids, to limit the number of database queries.
+     *
+     * @var array<string,int>
+     */
+    private static array $models2Ids = [];
+
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return int
+     */
+    protected function getModelId(Model $model): int
+    {
+        $modelClass = get_class($model);
+
+        return self::$models2Ids[$modelClass]
+            ?? $this->fetchModelId($modelClass);
+    }
+
+
+    /**
+     * @param string $modelClass
+     *
+     * @return int
+     */
+    private function fetchModelId(string $modelClass): int
+    {
+        $model = AclModel::select('id')->where('name', $modelClass)->first();
+
+        if ($model === null) $model = $this->createModelId($modelClass);
+
+        self::$models2Ids[$modelClass] = $model->id;
+
+        return $model->id;
+    }
+
+
+    /**
+     * @param string $modelClass
+     *
+     * @return \Rexpl\LaravelAcl\Models\AclModel
+     */
+    private function createModelId(string $modelClass): AclModel
+    {
+        return AclModel::create([
+            'name' => $modelClass,
+        ]);
+    }
+}

--- a/src/Models/AclModel.php
+++ b/src/Models/AclModel.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(Strict_types=1);
+
+namespace Rexpl\LaravelAcl\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AclModel extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'acl_models';
+
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/src/Models/GroupDependency.php
+++ b/src/Models/GroupDependency.php
@@ -12,7 +12,7 @@ class GroupDependency extends Model
      * @var string
      */
     protected $table = 'acl_group_dependencies';
-    
+
 
     /**
      * Indicates if the model should be timestamped.
@@ -20,16 +20,16 @@ class GroupDependency extends Model
      * @var bool
      */
     public $timestamps = false;
-    
-    
+
+
     /**
     * The attributes that are mass assignable.
     *
     * @var array<string>
     */
     protected $fillable = [
-        'ressource',
-        'ressource_id',
+        'model_id',
+        'record_id',
         'group_id',
         'permission_level',
     ];

--- a/src/Policy.php
+++ b/src/Policy.php
@@ -148,7 +148,7 @@ abstract class Policy
 
         if (!$this->hasPermission($user, $this->writePermission)) return false;
 
-        return (new Record($model)
+        return (new Record($model))
             ->canWriteRecord($user);
     }
 

--- a/src/Record.php
+++ b/src/Record.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rexpl\LaravelAcl;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Rexpl\LaravelAcl\Models\GroupDependency;
 use Illuminate\Support\Facades\Cache;
 use Rexpl\LaravelAcl\Exceptions\UnknownPermissionException;
@@ -16,7 +17,7 @@ final class Record
 
     /**
      * Permission level for read.
-     * 
+     *
      * @var int
      */
     public const READ = 4;
@@ -24,7 +25,7 @@ final class Record
 
     /**
      * Permission level for write.
-     * 
+     *
      * @var int
      */
     public const WRITE = 2;
@@ -32,7 +33,7 @@ final class Record
 
     /**
      * Permission level for delete.
-     * 
+     *
      * @var int
      */
     public const DELETE = 1;
@@ -40,7 +41,7 @@ final class Record
 
     /**
      * All allowed numbers.
-     * 
+     *
      * @var array<int>
      */
     public const FULL_RANGE = [1, 2, 3, 4, 5, 6, 7];
@@ -48,7 +49,7 @@ final class Record
 
     /**
      * Permission levels wich contain read permission.
-     * 
+     *
      * @var array<int>
      */
     public const READ_RANGE = [4, 5, 6, 7];
@@ -56,7 +57,7 @@ final class Record
 
     /**
      * Permission levels wich contain write permission.
-     * 
+     *
      * @var array<int>
      */
     public const WRITE_RANGE = [2, 3, 6, 7];
@@ -64,15 +65,15 @@ final class Record
 
     /**
      * Permission levels wich contain delete permission.
-     * 
+     *
      * @var array<int>
      */
     public const DELETE_RANGE = [1, 3, 5, 7];
 
-    
+
     /**
      * Should use cache.
-     * 
+     *
      * @var bool
      */
     protected bool $cache;
@@ -80,7 +81,7 @@ final class Record
 
     /**
      * How long to keep cached values.
-     * 
+     *
      * @var int
      */
     protected int $time;
@@ -88,7 +89,7 @@ final class Record
 
     /**
      * All the records models
-     * 
+     *
      * @var \Illuminate\Database\Eloquent\Collection
      */
     protected Collection $record;
@@ -96,21 +97,17 @@ final class Record
 
     /**
      * Are the records fetched.
-     * 
+     *
      * @var bool
      */
     protected bool $isRecordFetched = false;
 
 
     /**
-     * @param string $acronym
-     * @param int $id
-     * 
-     * @return void
+     * @param \Illuminate\Database\Eloquent\Model $model
      */
     public function __construct(
-        protected string $acronym,
-        protected int $id
+        protected Model $model
     ) {
         $this->cache = (bool) config('acl.record_cache', true);
         $this->time = (int) config('acl.record_duration', 300);
@@ -119,9 +116,9 @@ final class Record
 
     /**
      * See if record can be read only based on groups (without validation permissions).
-     * 
+     *
      * @param \Rexpl\LaravelAcl\User $user
-     * 
+     *
      * @return bool
      */
     public function canReadRecord(User $user): bool
@@ -132,9 +129,9 @@ final class Record
 
     /**
      * See if record can be writen only based on groups (without validation permissions).
-     * 
+     *
      * @param User $user
-     * 
+     *
      * @return bool
      */
     public function canWriteRecord(User $user): bool
@@ -145,9 +142,9 @@ final class Record
 
     /**
      * See if record can be deleted only based on groups (without validation permissions).
-     * 
+     *
      * @param User $user
-     * 
+     *
      * @return bool
      */
     public function canDeleteRecord(User $user): bool
@@ -158,11 +155,11 @@ final class Record
 
     /**
      * Can do with record.
-     * 
+     *
      * @param User $user
      * @param string $cacheIndex
      * @param array<int> $neededLevel
-     * 
+     *
      * @return bool
      */
     protected function canDoWithRecord(User $user, string $cacheIndex, array $neededLevel): bool
@@ -181,23 +178,23 @@ final class Record
 
             $result = $this->loopGroups($user->groups(), $neededLevel);
         }
-            
+
         return $result;
     }
 
 
     /**
      * Loops through each user group to see if it matches.
-     * 
+     *
      * @param array<int> $groups
      * @param array<int> $neededLevel
-     * 
+     *
      * @return bool
      */
     protected function loopGroups(array $groups, array $neededLevel): bool
     {
         foreach ($groups as $group) {
-            
+
             if ($this->isMatch($group, $neededLevel)) return true;
         }
 
@@ -207,16 +204,16 @@ final class Record
 
     /**
      * See if there is match between the group array and the record array.
-     * 
+     *
      * @param int $group
      * @param array<int> $neededLevel
-     * 
+     *
      * @return bool
      */
     protected function isMatch(int $group, array $neededLevel): bool
     {
         foreach ($this->record() as $row) {
-            
+
             if (
                 $row->group_id === $group
                 && in_array($row->permission_level, $neededLevel)
@@ -229,7 +226,7 @@ final class Record
 
     /**
      * Return all the depencies.
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function record(): Collection
@@ -239,7 +236,7 @@ final class Record
             $this->record = GroupDependency::where('ressource', $this->acronym)
                 ->where('ressource_id', $this->id)
                 ->get();
-            
+
             $this->isRecordFetched = true;
         }
 
@@ -249,10 +246,10 @@ final class Record
 
     /**
      * Assign new group to the record.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
      * @param int $level
-     * 
+     *
      * @return void
      */
     public function assign(Group|int $group, int $level): void
@@ -277,9 +274,9 @@ final class Record
 
     /**
      * Remove group from record.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
-     * 
+     *
      * @return void
      */
     public function remove(Group|int $group): void
@@ -293,7 +290,7 @@ final class Record
 
     /**
      * Refresh the record information.
-     * 
+     *
      * @return void
      */
     public function refresh()
@@ -304,7 +301,7 @@ final class Record
 
     /**
      * Delete the record.
-     * 
+     *
      * @return void
      */
     public function delete(): void

--- a/src/User.php
+++ b/src/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rexpl\LaravelAcl;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Rexpl\LaravelAcl\Exceptions\{
     UnknownPermissionException,
     ResourceNotFoundException
@@ -26,8 +27,8 @@ final class User
      * @param array<string> $permissions
      * @param array<int> $groups
      * @param array<\Rexpl\LaravelAcl\Internal\StdAclRow> $stdAcl
-     * @param GroupModel|null $group
-     * 
+     * @param \Rexpl\LaravelAcl\Models\Group|null $group
+     *
      * @return void
      */
     public function __construct(
@@ -41,7 +42,7 @@ final class User
 
     /**
      * Returns the group model.
-     * 
+     *
      * @return \Rexpl\LaravelAcl\Models\Group
      */
     protected function group(): GroupModel
@@ -52,14 +53,14 @@ final class User
 
     /**
      * Returns the group model.
-     * 
+     *
      * @return GroupModel
      */
     protected function fetchGroupModel(): GroupModel
     {
         $this->group = GroupModel::firstWhere('user_id', $this->id);
 
-        if (null === $this->group) {        
+        if (null === $this->group) {
             throw new ResourceNotFoundException(sprintf(
                 'Acl group with user id: %s, not found.', $this->id
             ));
@@ -67,11 +68,11 @@ final class User
 
         return $this->group;
     }
-    
-    
+
+
     /**
      * Return the user id.
-     * 
+     *
      * @return int
      */
     public function id(): int
@@ -82,7 +83,7 @@ final class User
 
     /**
      * Returns the user group ID.
-     * 
+     *
      * @return int
      */
     public function groupID(): int
@@ -93,9 +94,9 @@ final class User
 
     /**
      * See if the user has the permission.
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return bool
      */
     public function canWithPermission(string $name): bool
@@ -106,7 +107,7 @@ final class User
 
     /**
      * Returns all child groups (ids).
-     * 
+     *
      * @return array<int>
      */
     public function groups(): array
@@ -117,7 +118,7 @@ final class User
 
     /**
      * Returns all the permissions the user can use.
-     * 
+     *
      * @return array<string>
      */
     public function permissions(): array
@@ -128,7 +129,7 @@ final class User
 
     /**
      * Returns all the std acl of the user
-     * 
+     *
      * @return array<\Rexpl\LaravelAcl\Internal\StdAclRow>
      */
     public function stdAcl(): array
@@ -139,9 +140,9 @@ final class User
 
     /**
      * Add the group to the user.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
-     * 
+     *
      * @return static
      */
     public function addGroup(Group|int $group): static
@@ -157,9 +158,9 @@ final class User
 
     /**
      * Remove group from the user.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
-     * 
+     *
      * @return static
      */
     public function removeGroup(Group|int $group): static
@@ -174,7 +175,7 @@ final class User
 
     /**
      * Returns all the groups where the user is in.
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function allGroups(): Collection
@@ -185,10 +186,10 @@ final class User
 
     /**
      * Add standard acl group.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
      * @param int $level
-     * 
+     *
      * @return static
      */
     public function addStdGroup(Group|int $group, int $level): static
@@ -211,9 +212,9 @@ final class User
 
     /**
      * Remove standard acl group.
-     * 
+     *
      * @param \Rexpl\LaravelAcl\Group|int $group
-     * 
+     *
      * @return static
      */
     public function removeStdGroup(Group|int $group): static
@@ -228,18 +229,18 @@ final class User
 
     /**
      * Call when user creates a new record.
-     * 
-     * @param string $acronym
-     * @param int $id
-     * 
-     * @return Record
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return \Rexpl\LaravelAcl\Record
+     * @throws \Rexpl\LaravelAcl\Exceptions\UnknownPermissionException
      */
-    public function create(string $acronym, int $id): Record
+    public function create(Model $model): Record
     {
-        $record = new Record($acronym, $id);
+        $record = new Record($model);
 
         foreach ($this->stdAcl as $row) {
-            
+
             $record->assign(
                 $row->groupID,
                 $row->permissionLevel
@@ -252,7 +253,7 @@ final class User
 
     /**
      * Clear the user from the cache.
-     * 
+     *
      * @return void
      */
     public function clear(): void
@@ -263,7 +264,7 @@ final class User
 
     /**
      * Return an updated instance of the user.
-     * 
+     *
      * @return static
      */
     public function fresh(): static
@@ -276,7 +277,7 @@ final class User
 
     /**
      * Refresh the instance.
-     * 
+     *
      * @return static
      */
     public function refresh(): static
@@ -295,7 +296,7 @@ final class User
      * Delete the user.
      *
      * @param bool $clean
-     * 
+     *
      * @return void
      */
     public function delete(bool $clean = true): void

--- a/tests/UnitTest/UserTest.php
+++ b/tests/UnitTest/UserTest.php
@@ -19,7 +19,7 @@ class UserTest extends TestCase
 {
     /**
      * Test the creation/deletion of users.
-     * 
+     *
      * @return void
      */
     public function test_user_crud(): void
@@ -29,7 +29,7 @@ class UserTest extends TestCase
             'name' => 'test_user_crud'
         ]);
         $userAcl = Acl::newUser($user->id);
-        
+
         // The group id is fetched from db, so we successfully created the user because
         // a user is under the hood a group with a single user.
         $this->assertSame(
@@ -50,7 +50,7 @@ class UserTest extends TestCase
 
     /**
      * Test: add/remove groups to a user.
-     * 
+     *
      * @return void
      */
     public function test_user_groups(): void
@@ -96,7 +96,7 @@ class UserTest extends TestCase
 
     /**
      * Test: add/remove permissions to a user.
-     * 
+     *
      * @return void
      */
     public function test_user_permissions(): void
@@ -129,7 +129,7 @@ class UserTest extends TestCase
         $this->assertTrue(
             $userAcl->canWithPermission('permission:test_user_permissions')
         );
-        
+
         $userAcl->removePermission('permission:test_user_permissions');
 
         // We verify the group is removed.
@@ -147,7 +147,7 @@ class UserTest extends TestCase
 
     /**
      * Test the user std acl.
-     * 
+     *
      * @return void
      */
     public function test_user_std_acl(): void
@@ -176,7 +176,7 @@ class UserTest extends TestCase
         $record = TestModel::create([
             'name' => 'record:test_user_std_acl'
         ]);
-        $recordAcl = $userAcl->create('test', $record->id);
+        $recordAcl = $userAcl->create($record);
 
         // We now verify the group is successfully added to the new record.
         $this->assertTrue(
@@ -211,16 +211,16 @@ class UserTest extends TestCase
         $userAcl->delete();
 
         $this->expectException(UnknownPermissionException::class);
-        
+
         // We try to add an unknown permission level to the user.
         // The user and group are already deleted, we are just after the exception.
         $userAcl->addStdGroup($group, 8);
     }
 
-    
+
     /**
      * Test the cache functionality for useŕ retrieval.
-     * 
+     *
      * @return void
      */
     public function test_user_cache(): void
@@ -239,7 +239,7 @@ class UserTest extends TestCase
         $userAclInstance1->addGroup($group);
 
         // The groups of both of these instances should be the same because there groups are
-        // cached so even though we added a group in instance 1, they still ouput the same group list. 
+        // cached so even though we added a group in instance 1, they still ouput the same group list.
         $this->assertSame(
             $userAclInstance1->groups(),
             $userAclInstance2->groups()
@@ -266,7 +266,7 @@ class UserTest extends TestCase
 
     /**
      * We try to fetch a user with a deleted user group and make sure we get the expected exception.
-     * 
+     *
      * @return void
      */
     public function test_user_group_deleted(): void
@@ -280,7 +280,7 @@ class UserTest extends TestCase
         // We save it for compare later.
         $userGroupID = $userAcl->groupID();
 
-        // We create a group and add it otherwise we won't be able to retrieve the user once 
+        // We create a group and add it otherwise we won't be able to retrieve the user once
         // the user group is deleted. Adding this dummy group allows us to retrieve the user
         // once his personnal group has been deleted.
         $group = Acl::newGroup('group:test_user_group_deleted');


### PR DESCRIPTION
Currently it is necessary to "invent" an acronym for each model which uses policies, this implemantation allows to forget this and will use the model id which is based on the fully qulified namespace name of the model. This information is stored in a table. This table maps model names to a unique ID which can then be referenced from other tables.